### PR TITLE
Enable PEP 420 support

### DIFF
--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -75,7 +75,7 @@ def _mypy_impl(target, ctx):
 
     # types need to appear first in the mypy path since the module directories
     # are the same and mypy resolves the first ones, first.
-    mypy_path = ":".join(types + external_deps + unique_generated_dirs)
+    mypy_path = ":".join(types + external_deps + unique_generated_dirs + [ctx.label.package])
 
     output_file = ctx.actions.declare_file(ctx.rule.attr.name + ".mypy_stdout")
 

--- a/mypy/private/mypy.bzl
+++ b/mypy/private/mypy.bzl
@@ -59,6 +59,8 @@ def _mypy_impl(target, ctx):
             types.append(dep[PyTypeLibraryInfo].directory.path + "/site-packages")
         elif dep.label.workspace_root.startswith("external/"):
             external_deps.append(dep.label.workspace_root + "/site-packages")
+        elif dep.label.package != ctx.label.package:
+            external_deps.append(dep.label.package)
 
         if MypyCacheInfo in dep:
             upstream_caches.append(dep[MypyCacheInfo].directory)


### PR DESCRIPTION
This updates your PR by extending mypy_path some more and enables the PEP-420 support.

We certainly need to add tests for upstream to accept this change.

We should also clarify that this isn't a general problem with `rules_mypy` but the issue only occurs with (implicit namespace packages)[https://peps.python.org/pep-0420/].

In the meantime, could you update your branch with this?